### PR TITLE
Deprecated - `nfs: true`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #config.ssh.insert_key = true
 
   #Declare shared folder with Vagrant syntax
-  config.vm.synced_folder ".", "/var/aegir/platforms", synced_folder_type: nfs
+  config.vm.synced_folder ".", "/var/aegir/platforms", synced_folder_type: "nfs"
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #config.ssh.insert_key = true
 
   #Declare shared folder with Vagrant syntax
-  config.vm.synced_folder ".", "/var/aegir/platforms", nfs: true
+  config.vm.synced_folder ".", "/var/aegir/platforms", synced_folder_type: nfs
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"

--- a/puppet/manifests/nodes.pp
+++ b/puppet/manifests/nodes.pp
@@ -51,4 +51,3 @@ Drush::Run {
   drush_home => '/var/aegir',
   log        => '/var/aegir/drush.log',
 }
-


### PR DESCRIPTION
On install:

```
DEPRECATION: The 'nfs' setting for the Puppet provisioner is
deprecated. Please use the 'synced_folder_type' setting instead.
The 'nfs' setting will be removed in the next version of Vagrant.
```

This PR updates to synced_folder_type: nfs.
